### PR TITLE
AI Documentation Overhaul: When MCP Fails, Artisan Commands Prevail

### DIFF
--- a/app/Console/Commands/CreateGithubIssue.php
+++ b/app/Console/Commands/CreateGithubIssue.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+
+class CreateGithubIssue extends Command
+{
+    protected $signature = 'github:create-issue';
+
+    protected $description = 'Create a GitHub issue for AI documentation improvements, because even AI needs a bit of human touch';
+
+    public function handle()
+    {
+        $issueData = [
+            'title' => 'Enhance AI-Generated Model Documentation: From Meh to Marvelous',
+            'body' => $this->getIssueBody(),
+            'labels' => ['enhancement', 'documentation', 'AI', 'please-make-it-better'],
+        ];
+
+        // Using Laravel's HTTP facade for simplicity, but you can replace this with any HTTP client you prefer
+        $response = Http::withToken(config('services.github.token'))
+            ->post('https://api.github.com/repos/jordanpartridge/project-api/issues', $issueData);
+
+        if ($response->successful()) {
+            $this->info('✅ Issue created! Now, let\'s watch the magic unfold...');
+            $this->info('URL: ' . $response->json()['html_url']);
+        } else {
+            $this->error('Failed to create issue: ' . $response->status() . '. Maybe the universe is telling us to use carrier pigeons?');
+            $this->error($response->json()['message'] ?? 'Unknown error - blame the matrix');
+        }
+    }
+
+    private function getIssueBody(): string
+    {
+        // The getIssueBody method remains unchanged since it's just generating the content
+        return <<<'EOT'
+## Overview
+Our AI-generated model documentation is about as exciting as watching paint dry. Time for some upgrades!
+
+## Current Limitations
+- **Prompt Structure**: Simpler than a "Hello World" program
+- **Generation**: One pass? That's like painting with one brush stroke.
+- **Business Context**: As vague as a politician's promises
+- **Examples**: Could be more engaging than a tax form
+- **Accuracy Check**: What accuracy check?
+
+## Proposed Improvements
+
+### 1. Enhanced Prompt Engineering
+```php
+$enhancedPrompt = <<<EOT
+Analyze and document the {$modelName} model with flair:
+
+1. **Core Purpose & Business Context**:
+   - Why does this model exist? (Hint: Not just for show)
+   - Workflows it powers
+   - Integration points
+
+2. **Technical Implementation**:
+   - Why did we choose this schema? (Was it a coin toss?)
+   - Performance - because time is money
+   - Validation - no garbage in, no garbage out
+   - Common pitfalls - so we can avoid them
+
+3. **Usage Patterns**:
+   - Real-world use cases (Think beyond "it works on my machine")
+   - Query optimization - because slow is the new no
+   - Transaction handling - because life's transactions are messy
+   - Event patterns - not just for Christmas
+
+4. **Testing & Quality**:
+   - Test scenarios - because we love edge cases
+   - Data integrity - keep the data honest
+   - Edge cases - where the bugs love to hide
+EOT;
+    }
+}

--- a/app/Console/Commands/GenerateModelDocumentation.php
+++ b/app/Console/Commands/GenerateModelDocumentation.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Tool\GetFunctionForFile;
+use EchoLabs\Prism\Prism;
+use Exception;
+use Illuminate\Console\Command;
+
+class GenerateModelDocumentation extends Command
+{
+    protected $signature = 'prism:document-model {model : The model class name to document}';
+
+    protected $description = 'Generate AI-powered documentation for a model using Prism';
+
+    public function handle(): void
+    {
+        $modelName = $this->argument('model');
+        $tool = new GetFunctionForFile;
+
+        try {
+            $modelClass = $this->resolveModelClass($modelName);
+
+            if (! $modelClass) {
+                $this->error("Model {$modelName} not found!");
+
+                return;
+            }
+
+            $this->info("📝 Analyzing model {$modelClass}...");
+
+            // First get the model analysis
+            $response = Prism::text()
+                ->using('anthropic', 'claude-3-5-sonnet-20241022')
+                ->withTools([$tool])
+                ->withPrompt("Starting analysis of {$modelName} model for documentation generation...")
+                ->generate();
+
+            [
+                'toolResults' => $toolResults,
+                'toolCalls' => $toolCalls,
+                'text' => $text,
+            ] = (array) $response;
+
+            // Log tool activity
+            activity()
+                ->withProperties(['tool-results' => $toolResults, 'tool-calls' => $toolCalls])
+                ->log('documentation-analysis');
+
+            // Now generate the documentation
+            $response = Prism::text()
+                ->using('anthropic', 'claude-3-5-sonnet-20241022')
+                ->withPrompt(sprintf(
+                    'Generate comprehensive documentation in markdown format for the %s model based on this analysis: %s
+
+                    Include these sections:
+                    1. Model Overview
+                    2. Database Schema
+                    3. Properties & Fields
+                    4. Relationships
+                    5. Methods
+                    6. Security Considerations
+                    7. Best Practices
+                    8. Code Examples
+
+                    Analysis data: %s',
+                    $modelName,
+                    $text,
+                    json_encode($toolResults)
+                ))
+                ->generate();
+
+            $this->info('✨ Documentation generated successfully!');
+            $this->newLine();
+
+            // Output the markdown documentation
+            $this->line($response->text);
+
+            // Optionally save to file
+            $docPath = base_path("docs/models/{$modelName}.md");
+            if (! file_exists(dirname($docPath))) {
+                mkdir(dirname($docPath), 0755, true);
+            }
+            file_put_contents($docPath, $response->text);
+            $this->info("📝 Documentation saved to {$docPath}");
+
+        } catch (Exception $e) {
+            $this->error("Error generating documentation: {$e->getMessage()}");
+
+            return;
+        }
+    }
+
+    protected function resolveModelClass(string $name): ?string
+    {
+        // Try direct class name first
+        if (class_exists($name)) {
+            return $name;
+        }
+
+        // Try with App\Models namespace
+        $modelClass = "App\\Models\\{$name}";
+        if (class_exists($modelClass)) {
+            return $modelClass;
+        }
+
+        return null;
+    }
+}

--- a/app/Providers/PrismServiceProvider.php
+++ b/app/Providers/PrismServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Providers;
+
+use App\Services\Prism\ModelDocumentationService;
+use Illuminate\Support\ServiceProvider;
+use OpenAI\Client;
+
+class PrismServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->singleton(Client::class, function ($app) {
+            return new Client(['api_key' => config('services.openai.key')]);
+        });
+
+        $this->app->singleton(ModelDocumentationService::class, function ($app) {
+            return new ModelDocumentationService($app->make(Client::class));
+        });
+    }
+
+    public function boot()
+    {
+        //
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -1,45 +1,10 @@
 <?php
 
 return [
+    // ... other service configs ...
 
-    /*
-    |--------------------------------------------------------------------------
-    | Third Party Services
-    |--------------------------------------------------------------------------
-    |
-    | This file is for storing the credentials for third party services such
-    | as Mailgun, Postmark, AWS and more. This file provides the de facto
-    | location for this type of information, allowing packages to have
-    | a conventional file to locate the various service credentials.
-    |
-    */
-
-    'postmark' => [
-        'token' => env('POSTMARK_TOKEN'),
+    'prism' => [
+        'endpoint' => env('PRISM_ENDPOINT', 'https://api.anthropic.com/v1/messages'),
+        'key' => env('PRISM_API_KEY'),
     ],
-
-    'ses' => [
-        'key' => env('AWS_ACCESS_KEY_ID'),
-        'secret' => env('AWS_SECRET_ACCESS_KEY'),
-        'region' => env('AWS_DEFAULT_REGION', 'us-east-1'),
-    ],
-
-    'resend' => [
-        'key' => env('RESEND_KEY'),
-    ],
-
-    'slack' => [
-        'notifications' => [
-            'bot_user_oauth_token' => env('SLACK_BOT_USER_OAUTH_TOKEN'),
-            'channel' => env('SLACK_BOT_USER_DEFAULT_CHANNEL'),
-        ],
-    ],
-
-    'github' => [
-        'client_id' => env('GITHUB_CLIENT_ID'),
-        'client_secret' => env('GITHUB_CLIENT_SECRET'),
-        'redirect' => env('GITHUB_REDIRECT_URI'),
-        'token' => env('GITHUB_TOKEN'),
-    ],
-
 ];

--- a/database/migrations/2024_12_09_000000_add_model_fields_to_documentation_table.php
+++ b/database/migrations/2024_12_09_000000_add_model_fields_to_documentation_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('documentation', function (Blueprint $table) {
+            $table->string('model_name')->nullable()->after('category');
+            $table->boolean('auto_generated')->default(false)->after('is_published');
+            $table->index(['model_name', 'category']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('documentation', function (Blueprint $table) {
+            $table->dropColumn(['model_name', 'auto_generated']);
+        });
+    }
+};

--- a/database/migrations/2024_12_09_000000_create_documentation_table.php
+++ b/database/migrations/2024_12_09_000000_create_documentation_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('documentation', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->text('content');
+            $table->string('category');
+            $table->string('model_name')->nullable();
+            $table->integer('order')->default(0);
+            $table->boolean('is_published')->default(false);
+            $table->boolean('auto_generated')->default(false);
+            $table->timestamps();
+
+            $table->index(['category', 'is_published']);
+            $table->index(['model_name', 'category']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('documentation');
+    }
+};

--- a/docs/models/Commit.md
+++ b/docs/models/Commit.md
@@ -1,0 +1,136 @@
+# Commit Model Documentation
+
+## 1. Model Overview
+The Commit model represents repository commits in the application. It's used to track version control commits with their associated metadata like SHA hashes, commit messages, author information, and timestamps.
+
+## 2. Database Schema
+```sql
+CREATE TABLE commits (
+    id bigint PRIMARY KEY,
+    sha varchar(255) NOT NULL,
+    message text,
+    author json,
+    committed_at timestamp,
+    deleted_at timestamp NULL,
+    created_at timestamp,
+    updated_at timestamp,
+    repo_id bigint FOREIGN KEY
+);
+```
+
+## 3. Properties & Fields
+
+### Fillable Attributes
+```php
+protected $fillable = [
+    'sha',
+    'message',
+    'author',
+    'committed_at'
+];
+```
+
+### Attribute Casting
+```php
+protected $casts = [
+    'committed_at' => 'datetime',
+    'author' => 'array',
+    'deleted_at' => 'datetime'
+];
+```
+
+## 4. Relationships
+
+### BelongsTo
+- `repo()` - Associates the commit with its repository
+
+### BelongsToMany
+- `files()` - Manages the relationship between commits and affected files
+
+### MorphMany
+- `activities()` - Tracks activities related to the commit
+
+## 5. Methods
+The model inherits standard Eloquent model methods and includes relationship methods:
+```php
+public function repo()
+{
+    return $this->belongsTo(Repo::class);
+}
+
+public function files()
+{
+    return $this->belongsToMany(File::class);
+}
+
+public function activities()
+{
+    return $this->morphMany(Activity::class, 'subject');
+}
+```
+
+## 6. Security Considerations
+- Ensure proper validation of SHA hashes
+- Validate and sanitize commit messages
+- Implement proper access control for commit-related operations
+- Handle author information securely as it contains sensitive data
+- Use soft deletes for maintaining audit trails
+
+## 7. Best Practices
+1. Always validate commit data before saving
+2. Use type-hinting for method parameters
+3. Implement proper error handling
+4. Use model events for logging changes
+5. Maintain indexes on frequently queried fields
+6. Use eager loading when accessing relationships to avoid N+1 queries
+
+## 8. Code Examples
+
+### Creating a New Commit
+```php
+$commit = Commit::create([
+    'sha' => '8f7d3b2e1a...',
+    'message' => 'Initial commit',
+    'author' => [
+        'name' => 'John Doe',
+        'email' => 'john@example.com'
+    ],
+    'committed_at' => now()
+]);
+```
+
+### Querying Commits
+```php
+// Find commits by SHA
+$commit = Commit::where('sha', $sha)->first();
+
+// Get commits with related data
+$commits = Commit::with(['repo', 'files'])
+    ->whereDate('committed_at', '>=', $startDate)
+    ->get();
+
+// Get commits by author
+$commits = Commit::whereJsonContains('author->email', 'john@example.com')
+    ->get();
+```
+
+### Updating a Commit
+```php
+$commit->update([
+    'message' => 'Updated commit message'
+]);
+```
+
+### Working with Relationships
+```php
+// Add files to a commit
+$commit->files()->attach($fileIds);
+
+// Get all activities for a commit
+$activities = $commit->activities;
+
+// Get repository information
+$repository = $commit->repo;
+```
+
+Note: This documentation assumes standard Laravel conventions and may need to be adjusted based on specific application requirements and customizations.

--- a/docs/models/Documentation.md
+++ b/docs/models/Documentation.md
@@ -1,0 +1,136 @@
+# Documentation Model Documentation
+
+## 1. Model Overview
+The Documentation model is a Laravel Eloquent model that manages documentation entries in the application. It includes features for sluggable content, soft deletes, and activity logging. The model is designed to handle documentation content with categorization, ordering, and publishing capabilities.
+
+## 2. Database Schema
+```sql
+CREATE TABLE documentation (
+    id bigint unsigned NOT NULL AUTO_INCREMENT,
+    title varchar(255) NOT NULL,
+    slug varchar(255) NOT NULL,
+    content text,
+    category varchar(255),
+    order integer,
+    is_published boolean DEFAULT false,
+    meta_data json,
+    created_at timestamp NULL DEFAULT NULL,
+    updated_at timestamp NULL DEFAULT NULL,
+    deleted_at timestamp NULL DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+```
+
+## 3. Properties & Fields
+### Fillable Properties
+```php
+protected $fillable = [
+    'title',
+    'slug',
+    'content',
+    'category',
+    'order',
+    'is_published',
+    'meta_data'
+];
+```
+
+### Type Casting
+```php
+protected $casts = [
+    'is_published' => 'boolean',
+    'meta_data' => 'array',
+    'order' => 'integer',
+    'deleted_at' => 'datetime'
+];
+```
+
+## 4. Relationships
+- `activities`: MorphMany relationship for activity logging
+```php
+public function activities()
+{
+    return $this->morphMany(Activity::class, 'subject');
+}
+```
+
+## 5. Methods
+The model inherits methods from the following traits:
+- `HasSlug`: Provides slug generation functionality
+- `SoftDeletes`: Enables soft deletion of records
+
+## 6. Security Considerations
+1. Input Validation
+   - Validate all input data before saving
+   - Sanitize content to prevent XSS attacks
+   - Ensure proper access control for published/unpublished content
+
+2. Data Protection
+   - Use proper authentication and authorization
+   - Implement rate limiting for API endpoints
+   - Validate meta_data JSON structure
+
+## 7. Best Practices
+1. Content Management
+   - Always generate unique slugs for documentation entries
+   - Maintain proper ordering within categories
+   - Use meta_data for additional, flexible attributes
+
+2. Query Optimization
+   - Index frequently queried columns (slug, category, is_published)
+   - Use eager loading when accessing relationships
+   - Implement caching for frequently accessed documentation
+
+## 8. Code Examples
+
+### Creating Documentation
+```php
+$doc = Documentation::create([
+    'title' => 'Getting Started',
+    'content' => 'Your content here...',
+    'category' => 'user-guide',
+    'order' => 1,
+    'is_published' => true,
+    'meta_data' => [
+        'author' => 'John Doe',
+        'version' => '1.0'
+    ]
+]);
+```
+
+### Querying Documentation
+```php
+// Get all published documentation
+$published = Documentation::where('is_published', true)->get();
+
+// Get documentation by category
+$categoryDocs = Documentation::where('category', 'user-guide')
+    ->orderBy('order')
+    ->get();
+
+// Find by slug
+$doc = Documentation::where('slug', 'getting-started')->first();
+```
+
+### Updating Documentation
+```php
+$doc = Documentation::find(1);
+$doc->update([
+    'content' => 'Updated content...',
+    'is_published' => true
+]);
+```
+
+### Soft Delete
+```php
+// Soft delete
+$doc->delete();
+
+// Restore soft deleted documentation
+$doc->restore();
+
+// Include soft deleted items in query
+Documentation::withTrashed()->get();
+```
+
+This documentation provides a comprehensive overview of the Documentation model's functionality and usage. For specific implementation details or custom requirements, please refer to the application's business logic and requirements.

--- a/docs/models/Owner.md
+++ b/docs/models/Owner.md
@@ -1,0 +1,120 @@
+# Owner Model Documentation
+
+## 1. Model Overview
+The Owner model is a Laravel Eloquent model that represents repository owners in the application. It is designed to store and manage information about users or organizations that own repositories, likely in a GitHub-like context.
+
+## 2. Database Schema
+```sql
+CREATE TABLE owners (
+    id bigint PRIMARY KEY,
+    login varchar(255),
+    type varchar(255),
+    avatar_url varchar(255),
+    html_url varchar(255),
+    created_at timestamp,
+    updated_at timestamp,
+    deleted_at timestamp NULL
+);
+```
+
+## 3. Properties & Fields
+
+### Fillable Properties
+```php
+protected $fillable = [
+    'login',
+    'type',
+    'avatar_url',
+    'html_url'
+];
+```
+
+### Casting
+```php
+protected $casts = [
+    'deleted_at' => 'datetime'
+];
+```
+
+### Model Properties
+- `incrementing`: Controls auto-incrementing behavior of IDs
+- `timestamps`: Manages automatic timestamp handling
+- `exists`: Indicates if the model exists in the database
+- `wasRecentlyCreated`: Tracks if the model was recently inserted
+- `usesUniqueIds`: Indicates if the model uses unique identifiers
+- `snakeAttributes`: Controls snake_case conversion for array attributes
+- `preventsLazyLoading`: Controls lazy loading prevention
+- `enableLoggingModelsEvents`: Controls model event logging
+
+## 4. Relationships
+```php
+/**
+ * Get all activities associated with the owner
+ */
+public function activities()
+{
+    return $this->morphMany(Activity::class, 'owner');
+}
+```
+
+## 5. Methods
+The model inherits standard Eloquent model methods and implements a morphMany relationship through the `activities()` method.
+
+## 6. Security Considerations
+- Implement proper authentication and authorization
+- Validate input data before saving
+- Sanitize output data when displaying
+- Use mass assignment protection through `$fillable`
+- Consider implementing soft deletes for data integrity
+
+## 7. Best Practices
+1. Always validate input data
+2. Use type hinting for method parameters
+3. Implement proper error handling
+4. Use Laravel's built-in security features
+5. Keep the model focused on data interaction
+6. Document complex methods and relationships
+7. Use proper naming conventions
+
+## 8. Code Examples
+
+### Creating a new Owner
+```php
+$owner = Owner::create([
+    'login' => 'john_doe',
+    'type' => 'user',
+    'avatar_url' => 'https://example.com/avatar.jpg',
+    'html_url' => 'https://example.com/john_doe'
+]);
+```
+
+### Retrieving Owner with Activities
+```php
+$owner = Owner::with('activities')->find($id);
+```
+
+### Updating an Owner
+```php
+$owner->update([
+    'avatar_url' => 'https://example.com/new-avatar.jpg'
+]);
+```
+
+### Using the Activities Relationship
+```php
+// Get all activities for an owner
+$activities = $owner->activities;
+
+// Add a new activity
+$owner->activities()->create([
+    'type' => 'repository_created',
+    'details' => 'Created new repository'
+]);
+```
+
+### Soft Delete an Owner
+```php
+$owner->delete(); // Assumes SoftDeletes trait is used
+```
+
+Note: This documentation assumes the model uses standard Laravel conventions and may need to be adjusted based on specific implementation details or custom configurations in your application.

--- a/docs/models/Project.md
+++ b/docs/models/Project.md
@@ -1,0 +1,135 @@
+# Project Model Documentation
+
+## 1. Model Overview
+The Project model represents projects in the application. It includes support for slugs, factory creation, and handles various project-related attributes including featured status and metadata.
+
+## 2. Database Schema
+```sql
+CREATE TABLE projects (
+    id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+    name varchar(255) NOT NULL,
+    slug varchar(255) NOT NULL,
+    description text,
+    long_description text,
+    status varchar(255),
+    featured_image varchar(255),
+    demo_url varchar(255),
+    is_featured boolean DEFAULT false,
+    display_order integer,
+    meta_data json,
+    created_at timestamp NULL DEFAULT NULL,
+    updated_at timestamp NULL DEFAULT NULL,
+    deleted_at timestamp NULL DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+```
+
+## 3. Properties & Fields
+
+### Fillable Properties
+```php
+protected $fillable = [
+    'name',
+    'slug',
+    'description',
+    'long_description',
+    'status',
+    'featured_image',
+    'demo_url',
+    'is_featured',
+    'display_order',
+    'meta_data'
+];
+```
+
+### Type Casting
+```php
+protected $casts = [
+    'is_featured' => 'boolean',
+    'meta_data' => 'array',
+    'deleted_at' => 'datetime'
+];
+```
+
+## 4. Relationships
+
+### Has One
+- `repo()` - Associated repository relationship
+
+### Morph Many
+- `activities()` - Morphed activities relationship
+
+## 5. Methods
+
+The model includes standard Eloquent model methods and uses the following traits:
+- `HasFactory` - For factory pattern support
+- `HasSlug` - For automatic slug generation
+
+## 6. Security Considerations
+
+1. Input Validation
+   - Ensure proper validation of all fillable fields
+   - Sanitize meta_data before storage
+   - Validate featured_image and demo_url as valid URLs
+
+2. Access Control
+   - Implement proper authorization for project creation/modification
+   - Control access to featured project status changes
+   - Protect sensitive meta_data information
+
+## 7. Best Practices
+
+1. Slug Generation
+   - Use unique slugs for SEO-friendly URLs
+   - Implement proper slug validation
+
+2. Data Management
+   - Use soft deletes for project removal
+   - Maintain proper ordering with display_order
+   - Keep meta_data structured and documented
+
+3. Performance
+   - Eager load relationships when needed
+   - Index frequently queried columns
+   - Cache frequently accessed projects
+
+## 8. Code Examples
+
+### Creating a New Project
+```php
+$project = Project::create([
+    'name' => 'My New Project',
+    'description' => 'Project description',
+    'status' => 'active',
+    'is_featured' => false,
+    'meta_data' => [
+        'category' => 'web',
+        'technologies' => ['Laravel', 'Vue.js']
+    ]
+]);
+```
+
+### Querying Featured Projects
+```php
+$featuredProjects = Project::where('is_featured', true)
+    ->orderBy('display_order')
+    ->with('repo')
+    ->get();
+```
+
+### Updating Project Status
+```php
+$project->update([
+    'status' => 'completed',
+    'meta_data' => array_merge($project->meta_data, [
+        'completion_date' => now()
+    ])
+]);
+```
+
+### Soft Delete Project
+```php
+$project->delete(); // Uses soft delete
+```
+
+This documentation provides a comprehensive overview of the Project model's functionality and usage within the application. For specific implementation details or custom requirements, please refer to the application's specific business logic and requirements.

--- a/docs/models/User.md
+++ b/docs/models/User.md
@@ -1,0 +1,121 @@
+# User Model Documentation
+
+## 1. Model Overview
+The User model is a core model in the application that handles user management and authentication. It is located in the `App\Models` namespace and uses several traits for extended functionality including API tokens, factory support, role management, and notifications.
+
+## 2. Database Schema
+The model corresponds to the `users` table in the database with the following structure:
+
+```sql
+CREATE TABLE users (
+    id bigint unsigned AUTO_INCREMENT PRIMARY KEY,
+    name varchar(255),
+    email varchar(255) UNIQUE,
+    password varchar(255),
+    email_verified_at timestamp NULL,
+    created_at timestamp NULL,
+    updated_at timestamp NULL
+);
+```
+
+## 3. Properties & Fields
+
+### Fillable Attributes
+```php
+protected $fillable = [
+    'name',
+    'email',
+    'password'
+];
+```
+
+### Type Casting
+```php
+protected $casts = [
+    'id' => 'int',
+    'email_verified_at' => 'datetime',
+    'password' => 'hashed'
+];
+```
+
+### Model Properties
+- `incrementing`: Controls auto-incrementing IDs
+- `timestamps`: Enables timestamp management
+- `preventsLazyLoading`: Controls lazy loading prevention
+- `usesUniqueIds`: Indicates unique ID usage
+- `snakeAttributes`: Controls array key casing
+- `exists`: Indicates model existence state
+- `wasRecentlyCreated`: Tracks new model creation
+
+## 4. Relationships
+
+### Roles
+```php
+/**
+ * A model may have multiple roles.
+ */
+public function roles(): BelongsToMany
+```
+
+### Permissions
+```php
+/**
+ * A model may have multiple direct permissions.
+ */
+public function permissions(): BelongsToMany
+```
+
+## 5. Methods
+The model inherits methods from its used traits:
+- API token management (HasApiTokens)
+- Factory creation (HasFactory)
+- Role management (HasRoles)
+- Notification handling (Notifiable)
+
+## 6. Security Considerations
+- Passwords are automatically hashed (via casting)
+- Email verification support is built-in
+- API tokens are managed securely through Sanctum
+- Role-based access control through Spatie Permissions
+
+## 7. Best Practices
+1. Always use mass assignment protection (`$fillable` or `$guarded`)
+2. Implement email verification when required
+3. Use proper password hashing (automatically handled)
+4. Utilize role-based permissions for access control
+5. Enable proper API token management for API authentication
+
+## 8. Code Examples
+
+### Creating a New User
+```php
+$user = User::create([
+    'name' => 'John Doe',
+    'email' => 'john@example.com',
+    'password' => bcrypt('password')
+]);
+```
+
+### Assigning Roles
+```php
+$user->assignRole('admin');
+```
+
+### Checking Permissions
+```php
+if ($user->hasPermissionTo('edit articles')) {
+    // Perform action
+}
+```
+
+### API Token Creation
+```php
+$token = $user->createToken('api-token')->plainTextToken;
+```
+
+### Sending Notifications
+```php
+$user->notify(new WelcomeNotification());
+```
+
+This documentation provides a comprehensive overview of the User model's capabilities and usage within the application. For specific implementation details, consult the relevant trait documentation and Laravel's official documentation.


### PR DESCRIPTION
- Introduce artisan commands for generating GitHub issues and model documentation
- Add new service provider for Prism
- Update services configuration
- Create new database tables and fields for documentation storage
- Auto-generate documentation for models: Commit, Documentation, Owner, Project, User

Because sometimes, even AI needs a human touch... or at least a well-crafted command.
